### PR TITLE
Give violation messages some indentation hierarchy for readability

### DIFF
--- a/lib/axe/api/results.rb
+++ b/lib/axe/api/results.rb
@@ -13,10 +13,17 @@ module Axe
       end
 
       def failure_message
-        <<-MSG.gsub(/^\s*/,'')
-        Found #{violations.count} accessibility #{violations.count == 1 ? 'violation' : 'violations'}
-        #{ violations.each_with_index.map(&:failure_message).join("\n\n") }
-        MSG
+        [ violation_count_message ].concat(violations_failure_messages).join("\n")
+      end
+
+      private
+
+      def violation_count_message
+        "Found #{violations.count} accessibility #{violations.count == 1 ? 'violation' : 'violations'}"
+      end
+
+      def violations_failure_messages
+        violations.each_with_index.map(&:failure_message)
       end
     end
   end

--- a/lib/axe/api/results/check.rb
+++ b/lib/axe/api/results/check.rb
@@ -14,9 +14,7 @@ module Axe
         end
 
         def failure_message
-          <<-MSG
-          #{message}
-          MSG
+          "Violation Specifics: #{message}\n".insert(0, ' ' * 4)
         end
       end
     end

--- a/lib/axe/api/results/checked_node.rb
+++ b/lib/axe/api/results/checked_node.rb
@@ -13,10 +13,7 @@ module Axe
         end
 
         def failure_message
-          <<-MSG
-          #{super}
-          #{[].concat(any).concat(all).map(&:failure_message).join("\n")}
-          MSG
+          super.concat([].concat(any).concat(all).map(&:failure_message))
         end
       end
     end

--- a/lib/axe/api/results/node.rb
+++ b/lib/axe/api/results/node.rb
@@ -10,10 +10,17 @@ module Axe
         end
 
         def failure_message
-          <<-MSG
-          #{Array(target).join(', ')}
-          #{html}
-          MSG
+          [ selector_message, node_html ]
+        end
+
+        private
+
+        def selector_message
+          "Selector: #{Array(target).join(', ')}".insert(0, " " * 4)
+        end
+
+        def node_html
+          "HTML: #{html.gsub(/^\s*|\n*/,'')}".insert(0, " " * 4)
         end
       end
     end

--- a/lib/axe/api/results/rule.rb
+++ b/lib/axe/api/results/rule.rb
@@ -16,10 +16,20 @@ module Axe
         end
 
         def failure_message(index)
-          <<-MSG
-          #{index+1}) #{help}: #{helpUrl}
-          #{nodes.map(&:failure_message).join("\n")}
-          MSG
+          [
+            help_message(index+1),
+            node_count_message
+          ].concat(nodes.map(&:failure_message))
+        end
+
+        private
+
+        def help_message(count)
+          "#{count}) #{help}: #{helpUrl}\n"
+        end
+
+        def node_count_message
+          "#{nodes.length} #{nodes.length == 1 ? 'node' : 'nodes'} were found with the violation:".insert(0, " " * 2)
         end
       end
     end


### PR DESCRIPTION
Provide a nicer format for displaying violation messages.

<img width="1264" alt="screen shot 2016-04-25 at 5 19 34 pm" src="https://cloud.githubusercontent.com/assets/405235/14904376/babedcb2-0d5c-11e6-986e-fb7a4e271465.png">

@jasonkarns Can you give it a look over?