### PR TITLE
More graceful handling of malformed results returned from axe-core

### DIFF
--- a/lib/axe/api/results/checked_node.rb
+++ b/lib/axe/api/results/checked_node.rb
@@ -24,9 +24,10 @@ module Axe
         private
 
         def fix(checks, message)
+          valid_checks = checks.reject{|c| c.nil?}
           [
-            (message unless checks.empty?),
-            checks.map(&:failure_message).map{|line| line.prepend("- ") }
+            (message unless valid_checks.empty?),
+            valid_checks.map(&:failure_message).map{|line| line.prepend("- ") }
           ].compact
         end
       end

--- a/lib/axe/api/results/node.rb
+++ b/lib/axe/api/results/node.rb
@@ -20,7 +20,7 @@ module Axe
         end
 
         def node_html
-          "HTML: #{html.gsub(/^\s*|\n*/,'')}"
+          "HTML: #{html.gsub(/^\s*|\n*/,'')}" unless html.nil?
         end
       end
     end

--- a/lib/axe/api/results/rule.rb
+++ b/lib/axe/api/results/rule.rb
@@ -22,7 +22,7 @@ module Axe
               helpUrl,
               node_count_message,
               "",
-              nodes.map(&:failure_messages).map{|n| n.push("")}.flatten.map(&indent)
+              nodes.reject{|n| n.nil?}.map(&:failure_messages).map{|n| n.push("")}.flatten.map(&indent)
 
             ].flatten.map(&indent)
           ]
@@ -31,7 +31,7 @@ module Axe
         private
 
         def indent
-          -> (line) { line.prepend(" " * 4) }
+          -> (line) { line.prepend(" " * 4) unless line.nil? }
         end
 
         def title_message(count)

--- a/spec/lib/axe/api/results_spec.rb
+++ b/spec/lib/axe/api/results_spec.rb
@@ -5,39 +5,70 @@ module Axe::API
   describe Results do
 
     describe "#failure_message" do
-      subject {
-        Results.new "violations" => [ {
-          "help" => "V1 help",
-          "helpUrl" => "V1 url",
-          "nodes" => [ {
-            "target" => ["#target-1-1"],
-            "html" => "V1 html",
-            "any" => [ { "message" => "Fix from any 1" } ],
-            "all" => [ { "message" => "Fix from all 1" } ]
+      context "when the results objects are complete" do
+        subject {
+          Results.new "violations" => [ {
+            "help" => "V1 help",
+            "helpUrl" => "V1 url",
+            "nodes" => [ {
+              "target" => ["#target-1-1"],
+              "html" => "V1 html",
+              "any" => [ { "message" => "Fix from any 1" } ],
+              "all" => [ { "message" => "Fix from all 1" } ]
+            } ]
+          }, {
+            "help" => "V2 help",
+            "helpUrl" => "V2 url",
+            "nodes" => [ {
+              "target" => ["#target-2-1", "#target-2-2"],
+              "html" => "V2 html",
+              "any" => [ { "message" => "Fix from any 2" } ],
+              "all" => [ { "message" => "Fix from all 2" } ]
+            } ]
           } ]
-        }, {
-          "help" => "V2 help",
-          "helpUrl" => "V2 url",
-          "nodes" => [ {
-            "target" => ["#target-2-1", "#target-2-2"],
-            "html" => "V2 html",
-            "any" => [ { "message" => "Fix from any 2" } ],
-            "all" => [ { "message" => "Fix from all 2" } ]
+        }
+
+        it "should return formatted error message" do
+          subject.failure_message.tap do |message|
+            expect(message).to include("Found 2 accessibility violations")
+
+            expect(message).to include "V1 help", "V2 help"
+            expect(message).to include "V1 url", "V2 url"
+
+            expect(message).to include "V1 html", "V2 html"
+            expect(message).to include "#target-1-1", "#target-2-1, #target-2-2"
+
+            expect(message).to include "Fix from any 1", "Fix from all 1", "Fix from any 2", "Fix from all 2"
+          end
+        end
+      end
+
+      context "when the results objects are incomplete" do
+        subject { 
+          Results.new 'violations' => [ {
+            'help' => nil,
+            'helpUrl' => nil,
+            'nodes' => nil
+          }, {
+            'help' => 'V2 help',
+            'helpUrl' => 'V2 url',
+            'nodes' => [ {
+              'target' => nil,
+              'html' => nil,
+              'any' => nil,
+              'all' => nil
+            }, {
+              'target' => [nil],
+              'html' => nil,
+              'any' => [nil],
+              'all' => [nil],
+
+            }, nil ]
           } ]
-        } ]
-      }
+        }
 
-      it "should return formatted error message" do
-        subject.failure_message.tap do |message|
-          expect(message).to include("Found 2 accessibility violations")
-
-          expect(message).to include "V1 help", "V2 help"
-          expect(message).to include "V1 url", "V2 url"
-
-          expect(message).to include "V1 html", "V2 html"
-          expect(message).to include "#target-1-1", "#target-2-1, #target-2-2"
-
-          expect(message).to include "Fix from any 1", "Fix from all 1", "Fix from any 2", "Fix from all 2"
+        it "should gracefully handle formatting" do
+          expect(subject.failure_message).to_not be_nil
         end
       end
     end


### PR DESCRIPTION
This closes dequelabs/axe-matchers#9

Creating a test as an example of malformed results, and adding the
appropriate nil checks for formatting the message displayed in the test
results.