### PR TITLE
Capybara complains that :tag_name selector is unknown

### DIFF
--- a/lib/axe/loader.rb
+++ b/lib/axe/loader.rb
@@ -23,7 +23,7 @@ module Axe
     end
 
     def iframes
-      @page.find_elements(:tag_name, "iframe")
+      @page.find_elements(:css, "iframe")
     end
   end
 end

--- a/spec/lib/axe/loader_spec.rb
+++ b/spec/lib/axe/loader_spec.rb
@@ -17,6 +17,28 @@ module Axe
         expect(Axe::Hooks).to receive(:run_after_load).with(lib)
         loader.call(:source)
       end
+
+      context "when skipping iframes" do
+        before do
+          allow(Axe::Configuration.instance).to receive(:skip_iframes) { false }
+        end
+
+        it "should find iframes with the css finder" do
+          loader.call(:source)
+          expect(page).to have_received(:find_elements).with(:css, "iframe")
+        end
+      end
+
+      context "when not skipping iframes" do
+        before do
+          allow(Axe::Configuration.instance).to receive(:skip_iframes) { true }
+        end
+
+        it "should not find iframes" do
+          loader.call(:source)
+          expect(page).not_to have_received(:find_elements)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Due to a recent commit (https://github.com/jnicklas/capybara/commit/1af5c17d658fff54c563d34dda125a1369043159), Capybara now emits a warning message when using the `:tag_name` finder:

```
Unknown selector type (:tag_name), defaulting to :css - This will raise an exception in a future version of Capybara
```

The source of this warning is localized to `Axe::Loader#iframes` (https://github.com/dequelabs/axe-matchers/blob/master/lib/axe/loader.rb#L26).

This commit finds iframes using Capybara's CSS finder, rather than the tag name finder, and adds specs around the iframe_skip configuration setting.
