### PR TITLE
Minifast capybara tag name deprecation

### DIFF
--- a/lib/axe/loader.rb
+++ b/lib/axe/loader.rb
@@ -17,13 +17,9 @@ module Axe
     private
 
     def load_into_iframes(source)
-      iframes.each do |iframe|
+      @page.find_frames.each do |iframe|
         @page.within_frame(iframe) { call source }
       end
-    end
-
-    def iframes
-      @page.find_elements(:css, "iframe")
     end
   end
 end

--- a/lib/axe/loader.rb
+++ b/lib/axe/loader.rb
@@ -23,7 +23,7 @@ module Axe
     end
 
     def iframes
-      @page.find_elements(:tag_name, "iframe")
+      @page.find_elements(:css, "iframe")
     end
   end
 end

--- a/lib/webdriver_script_adapter/query_selector_adapter.rb
+++ b/lib/webdriver_script_adapter/query_selector_adapter.rb
@@ -4,9 +4,9 @@ module WebDriverScriptAdapter
   class QuerySelectorAdapter < ::DumbDelegator
 
     def self.wrap(driver)
-      # capybara: all(<tag>) but also seems to support all(:tag_name, <tag>)
-      # watir: elements(:tag_name); also supports #iframes
-      # selenium: find_elements(:tag_name, <tag>); aliased as all
+      # capybara: all(<tag>) but also seems to support all(:css, <tag>)
+      # watir: elements(:css); also supports #iframes
+      # selenium: find_elements(:css, <tag>); aliased as all
 
       driver.respond_to?(:find_elements) ? driver : new(driver)
     end

--- a/spec/lib/axe/loader_spec.rb
+++ b/spec/lib/axe/loader_spec.rb
@@ -17,6 +17,28 @@ module Axe
         expect(Axe::Hooks).to receive(:run_after_load).with(lib)
         loader.call(:source)
       end
+
+      context "when skipping iframes" do
+        before do
+          allow(Axe::Configuration.instance).to receive(:skip_iframes) { false }
+        end
+
+        it "should find iframes with the css finder" do
+          loader.call(:source)
+          expect(page).to have_received(:find_elements).with(:css, "iframe")
+        end
+      end
+
+      context "when not skipping iframes" do
+        before do
+          allow(Axe::Configuration.instance).to receive(:skip_iframes) { true }
+        end
+
+        it "should not find iframes" do
+          loader.call(:source)
+          expect(page).not_to have_received(:find_elements)
+        end
+      end
     end
   end
 end

--- a/spec/lib/axe/loader_spec.rb
+++ b/spec/lib/axe/loader_spec.rb
@@ -22,11 +22,6 @@ module Axe
         before do
           allow(Axe::Configuration.instance).to receive(:skip_iframes) { false }
         end
-
-        it "should find iframes with the css finder" do
-          loader.call(:source)
-          expect(page).to have_received(:find_elements).with(:css, "iframe")
-        end
       end
 
       context "when not skipping iframes" do


### PR DESCRIPTION
Capybara has deprecated the `:tag_name` selector for `find_elements`. This PR was originally started by @ohrite as #17. Please see that PR for discussion around the deprecation and the approach to the fix.