### PR TITLE
Updates axe-core, and replaces axe.a11yCheck with axe.run

### DIFF
--- a/axe-matchers.gemspec
+++ b/axe-matchers.gemspec
@@ -39,12 +39,12 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rspec', '~> 3.6'
   spec.add_development_dependency 'rspec-its', '~> 1.2'
-  spec.add_development_dependency 'rspec_junit_formatter', '~> 0.2'
+  spec.add_development_dependency 'rspec_junit_formatter', '~> 0.3'
   spec.add_development_dependency 'sinatra', '~> 2.0'
   # drivers
   spec.add_development_dependency 'capybara', '~> 2.13'
   spec.add_development_dependency 'capybara-webkit', '~> 1.14'
-  spec.add_development_dependency 'poltergeist', '~> 1.15'
-  spec.add_development_dependency 'selenium-webdriver', '~> 3.4'
-  spec.add_development_dependency 'watir', '~> 6.2'
+  spec.add_development_dependency 'poltergeist', '~> 1.16'
+  spec.add_development_dependency 'selenium-webdriver', '~> 3.5'
+  spec.add_development_dependency 'watir', '~> 6.6'
 end

--- a/axe-matchers.gemspec
+++ b/axe-matchers.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name        = 'axe-matchers'
-  spec.version     = '1.3.4'
+  spec.version     = '1.4.0'
   spec.license     = 'MPL-2.0'
   spec.authors     = ['Deque Systems', 'Test Double']
   spec.email       = ['helpdesk@deque.com', 'hello@testdouble.com']

--- a/docs/Cucumber.md
+++ b/docs/Cucumber.md
@@ -42,7 +42,7 @@ To construct an axe accessibility Cucumber step, begin with the base step, and a
 Then the page should be accessible
 ```
 
-The base step is the core component of the step. It is a complete step on its own and will verify the currently loaded page is accessible using the default configuration of [axe.a11yCheck][a11ycheck] (the entire document is checked using the default rules).
+The base step is the core component of the step. It is a complete step on its own and will verify the currently loaded page is accessible using the default configuration of [axe.run][axe-run] (the entire document is checked using the default rules).
 
 ### Inclusion clause
 
@@ -148,7 +148,7 @@ Then the page should be accessible according to: best-practice and checking: ari
 [exclusive-rules-clause]: #exclusive-rules-clause
 [skipping-rules-clause]: #skipping-rules-clause
 
-[a11ycheck]: https://github.com/dequelabs/axe-core/blob/master/doc/API.md#api-name-axea11ycheck
+[axe-run]: https://github.com/dequelabs/axe-core/blob/master/doc/API.md#api-name-axerun
 [context-param]: https://github.com/dequelabs/axe-core/blob/master/doc/API.md#context-parameter
 [options-param]: https://github.com/dequelabs/axe-core/blob/master/doc/API.md#options-parameter
 [rules]: https://github.com/dequelabs/axe-core/blob/master/doc/rule-descriptions.md

--- a/lib/axe/api/a11y_check.rb
+++ b/lib/axe/api/a11y_check.rb
@@ -13,7 +13,7 @@ require 'axe/core'
 module Axe
   module API
     class A11yCheck
-      JS_NAME = "a11yCheck"
+      JS_NAME = "run"
       METHOD_NAME = "#{Core::JS_NAME}.#{JS_NAME}"
 
       extend Forwardable
@@ -37,11 +37,18 @@ module Axe
       private
 
       def audit(page)
-        yield page.execute_async_script "#{METHOD_NAME}.apply(#{Core::JS_NAME}, arguments)", @context.to_json, @options.to_json
+        yield page.execute_async_script "#{METHOD_NAME}.apply(#{Core::JS_NAME}, arguments)", *js_args
+      end
+
+      def js_args
+        [ @context, @options ]
+          .reject(&:empty?)
+          .map(&:to_json)
       end
 
       def to_js
-        "#{METHOD_NAME}(#{@context}, #{@options}, callback);"
+        str_args = (js_args + [ 'callback']).join(', ')
+        "#{METHOD_NAME}(#{str_args});"
       end
     end
   end

--- a/lib/axe/api/context.rb
+++ b/lib/axe/api/context.rb
@@ -17,17 +17,16 @@ module Axe
       end
 
       def to_hash
-        {}.tap do |context_param|
-          # omit empty arrays
-          # (include must not be present if empty)
-          # (exclude is allowed to be empty; but meh)
-          context_param[:include] = @inclusion unless @inclusion.empty?
-          context_param[:exclude] = @exclusion unless @exclusion.empty?
-        end
+        { include: @inclusion, exclude: @exclusion }
+          .reject { |k, v| v.empty? }
       end
 
       def to_json
         to_hash.to_json
+      end
+
+      def empty?
+        to_hash.empty?
       end
 
       alias :to_s :to_json

--- a/lib/axe/api/options.rb
+++ b/lib/axe/api/options.rb
@@ -22,6 +22,10 @@ module Axe
         to_hash.to_json
       end
 
+      def empty?
+        to_hash.empty?
+      end
+
       alias :to_s :to_json
 
     end

--- a/lib/axe/core.rb
+++ b/lib/axe/core.rb
@@ -27,7 +27,7 @@ module Axe
     def already_loaded?
       @page.evaluate_script <<-JS
         window.#{JS_NAME} &&
-        typeof #{JS_NAME}.a11yCheck === 'function'
+        typeof #{JS_NAME}.run === 'function'
       JS
     end
 

--- a/lib/webdriver_script_adapter/execute_async_script_adapter.rb
+++ b/lib/webdriver_script_adapter/execute_async_script_adapter.rb
@@ -51,7 +51,7 @@ module WebDriverScriptAdapter
     end
 
     def callback(resultsIdentifier)
-      "function(returnValue){ #{resultsIdentifier} = returnValue; }"
+      "function(err, returnValue){ #{resultsIdentifier} = (err || returnValue); }"
     end
 
     def async_wrapper(script, *args)

--- a/spec/lib/axe/api/a11y_check_spec.rb
+++ b/spec/lib/axe/api/a11y_check_spec.rb
@@ -67,10 +67,9 @@ module Axe::API
       let(:results) { spy('results') }
       let(:audit) { spy('audit') }
 
-      it "should execute the axe.a11yCheck JS method" do
-        pending "validate args correctly"
+      it "should execute the axe.run JS method" do
         subject.call(page)
-        expect(page).to have_received(:execute_async_script).with("axe.a11yCheck.apply(axe, arguments)", "document", "{}")
+        expect(page).to have_received(:execute_async_script).with("axe.run.apply(axe, arguments)")
       end
 
       it "should return an audit" do
@@ -84,7 +83,7 @@ module Axe::API
       end
 
       it "should include the original invocation string" do
-        expect(Audit).to receive(:new).with("axe.a11yCheck({}, {}, callback);", instance_of(Results))
+        expect(Audit).to receive(:new).with("axe.run(callback);", instance_of(Results))
         subject.call(page)
       end
     end

--- a/spec/lib/axe/api/context_spec.rb
+++ b/spec/lib/axe/api/context_spec.rb
@@ -83,6 +83,32 @@ module Axe::API
       end
     end
 
+    describe "#empty?" do
+      context "without inclusion or exclusion rules" do
+        it "should be empty" do
+          subject.instance_variable_set :@inclusion, []
+          subject.instance_variable_set :@exclusion, []
+          expect(subject.empty?).to be(true)
+        end
+      end
+
+      context "with inclusion rules" do
+        it "should not be empty" do
+          subject.instance_variable_set :@inclusion, [ 'foo' ]
+          subject.instance_variable_set :@exclusion, []
+          expect(subject.empty?).to be(false)
+        end
+      end
+
+      context "with exclusion rules" do
+        it "should not be empty" do
+          subject.instance_variable_set :@inclusion, []
+          subject.instance_variable_set :@exclusion, [ 'foo' ]
+          expect(subject.empty?).to be(false)
+        end
+      end
+    end
+
     describe "#to_json" do
       context "without an inclusion" do
         context "without an exclusion" do

--- a/spec/lib/axe/api/options_spec.rb
+++ b/spec/lib/axe/api/options_spec.rb
@@ -56,6 +56,32 @@ module Axe::API
       end
     end
 
+    describe "#empty?" do
+      context "without rules or cutom options" do
+        it "should be empty" do
+          subject.instance_variable_set :@rules, {}
+          subject.instance_variable_set :@custom, {}
+          expect(subject.empty?).to be(true)
+        end
+      end
+
+      context "with rules" do
+        it "should not be empty" do
+          subject.instance_variable_set :@rules, { foo: 'bar' }
+          subject.instance_variable_set :@custom, {}
+          expect(subject.empty?).to be(false)
+        end
+      end
+
+      context "with cutom options" do
+        it "should not be empty" do
+          subject.instance_variable_set :@rules, {}
+          subject.instance_variable_set :@custom, { foo: 'bar' }
+          expect(subject.empty?).to be(false)
+        end
+      end
+    end
+
     describe "#to_json" do
       context "without duplicates" do
         before :each do

--- a/spec/lib/webdriver_script_adapter/execute_async_script_adapter_spec.rb
+++ b/spec/lib/webdriver_script_adapter/execute_async_script_adapter_spec.rb
@@ -23,7 +23,7 @@ module WebDriverScriptAdapter
 
       it "should pass a callback as the last argument" do
         subject.execute_async_script :foo
-        expect(driver).to have_received(:execute_script).with a_string_matching(/function\(returnValue\){ window\['.*'\] = returnValue; \}\)/)
+        expect(driver).to have_received(:execute_script).with a_string_matching(/function\(err, returnValue\){ window\['.*'\] = \(err \|\| returnValue\); \}\)/)
       end
 
       it "should attempt to evaluate the stored async results" do
@@ -40,7 +40,7 @@ module WebDriverScriptAdapter
 
         it "should use the configured result identifier in the callback" do
           subject.execute_async_script :foo
-          expect(driver).to have_received(:execute_script).with a_string_ending_with "function(returnValue){ window['foo'] = returnValue; });"
+          expect(driver).to have_received(:execute_script).with a_string_ending_with "function(err, returnValue){ window['foo'] = (err || returnValue); });"
         end
 
         it "should use the configured result identifier in the callback" do


### PR DESCRIPTION
* Upgrades axe-core to version 2.3.1
* Upgrades gem dependencies
* Replaces axe.a11yCheck with axe.run

    `axe.a11yCheck` has been deprecated, so this commit replaces it with
    `axe.run`

    The old signature for `axe.a11yCheck` was:
    ``` rb
    // with populated context and options axe.a11yCheck(context, options,
    function(results) { ... });

    // with empty context and options axe.a11yCheck({}, {}, function(results) {
    ... });
    ```

    The new signature for `axe.run` is:
    ``` rb
    // with populated context and options axe.run(context, options,
    function(err, results) { ... });

    // with empty context and options axe.run(function(err, results) { ... });
    ```