### PR TITLE
Axe 3 upgrade

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ bin/
 node_modules/
 spec/examples.txt
 results/
+package-lock.json

--- a/Brewfile
+++ b/Brewfile
@@ -1,3 +1,2 @@
-brew 'phantomjs'
 brew 'chromedriver'
 brew 'node'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@
 
 1. Ruby 2.0.0 or later.
 2. Bundler for gem dependencies
-3. (optional) Brewdler for system dependencies (phantomjs, chromedriver, etc)
+3. (optional) Brewdler for system dependencies (chromedriver, etc)
 4. Rake as task runner
 5. RSpec for unit and integration tests
 6. Cucumber for smoke tests
@@ -37,12 +37,12 @@ All subsequent commands (when invoking rake, rspec, cucumber, etc) must be prefi
 
 Most of the dependencies necessary for running the various test suite configurations are provided via gems and managed by bundler.
 
-However, to run the tests against phantomjs, you will need phantomjs installed. And to run the tests against chrome, you will need chromedriver. Both of these are system dependencies. These can be installed manually, or through homebrew. To ease installation of these non-gem dependencies, a `Brewfile` is provided.
+To run the tests against chrome, you will need chromedriver as a system dependency. This can be installed manually, or through homebrew. To ease installation of non-gem dependencies, a `Brewfile` is provided.
 
-It is recommended that you visually inspect the Brewfile to ensure there are no conflicts with existing tools already on your system. Each tool can be installed manually as necessary, and are even optional. (phantomjs and chromedriver are only necessary if running the cucumber smoke tests against phantomjs and chrome, respectively)
+It is recommended that you visually inspect the Brewfile to ensure there are no conflicts with existing tools already on your system. Each tool can be installed manually as necessary.
 
     `brew tap homebrew/bundle` to install brewdler
-    `brew bundle` to install phantomjs, chromedriver, and node
+    `brew bundle` to install chromedriver and node
 
 Additionally, to test against Safari, the SafariDriver extension is needed. Install it (using Safari) from http://selenium-release.storage.googleapis.com/2.48/SafariDriver.safariextz.
 
@@ -66,6 +66,7 @@ Rake is the standard task runner. For a list of configured tasks, run `rake -T`.
  - `rake npm:install`: install axe-core (and any other npm dependencies)
  - `rake npm:update`: update axe-core (and any other npm dependencies) to latest version allowed by package.json
  - `rake npm:upgrade`: upgrade axe-core dependency to latest version available, overwriting (and saving to) package.json
+ - `rake npm:next`: upgrade axe-core dependency to latest prerelease version, overwriting (and saving to) package.json
 
 ## Releasing
 
@@ -92,28 +93,26 @@ see also: `rake -T spec`
 
 ## Cucumber Features (smoke tests)
 
-There is a single feature that does a minimal test of the matchers + cucumber steps + axe js library. It is intended as a smoke test to validate against multiple webdrivers. Unless a specific profile is specified, cucumber will run the default profile which drives webkit (headless) with capybara. Alternatiely, you may specify the driver and browser combination:
+There is a single feature that does a minimal test of the matchers + cucumber steps + axe js library. It is intended as a smoke test to validate against multiple webdrivers. Unless a specific profile is specified, cucumber will run the default profile which drives webkit (headless) with capybara. Alternatively, you may specify the driver and browser combination:
 
 ```
-cucumber -p capybara -p poltergeist
+cucumber -p capybara -p chrome-headless
 cucumber -p capybara -p webkit
 cucumber -p capybara -p firefox
-cucumber -p selenium -p phantomjs
 cucumber -p watir -p chrome
 ```
 
-First specify the driver (one of: `capybara`, `selenium` or `watir`), and choose the browser (`firefox`, `chrome`, `safari`, `phantomjs`). All three drivers support all four browsers. Capybara alone also supports `webkit` and `poltergeist`.
+First specify the driver (one of: `capybara`, `selenium` or `watir`), and choose the browser (`firefox`, `chrome`, `safari`). All three drivers support all four browsers. Capybara alone also supports `webkit` and `chrome-headless`.
 
 These profile configurations can also be run via rake: `rake cucumber:{driver}:{browser}`. For example:
 
 ```
 rake cucumber:capybara:firefox
 rake cucumber:selenium:chrome
-rake cucumber:watir:phantomjs
 ```
 
 see `rake -T cucumber`
 
-You may omit the browser (`rake cucumber:capybara`) and it will run the features under every configured browser for the given driver. Alternatively, you may omit the driver (`rake cucumber:firefox`) and it will run the features with each driver for the given browser. Additionally, there are special options to run every driver/browser combination `rake cucumber:all`, or only the headless browsers `rake cucumber:headless`. (Headless combinations are capybara+poltergeist, capybara+webkit, capybara+phantomjs, selenium+phantomjs, watir+phantomjs)
+You may omit the browser (`rake cucumber:capybara`) and it will run the features under every configured browser for the given driver. Alternatively, you may omit the driver (`rake cucumber:firefox`) and it will run the features with each driver for the given browser. Additionally, there are special options to run every driver/browser combination `rake cucumber:all`, or only the headless browsers `rake cucumber:headless`. (Headless combinations are capybara+chrome and capybara+webkit)
 
 The profiles are configured in `config/cucumber.yml`. Each profile explicitly requires the appropriate env file based on the driver. This overrides Cucumber's default behavior of automatically requiring the entire `features/support/*.rb` tree. Each of the driver-specific env files in turn requires the common `features/support/env.rb` file. The driver-specific files are intended to import, configure, and wrap each of the drivers such that the step definitions can interact with any of the drivers via the same commands.

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Read the documentation for the [RSpec Integration][rspec-integration]
 
 # The Accessibility Rules
 
+axe-matchers uses axe-core@3x, which can test for accessibility inside of Shadow DOM HTML subtrees. See the [axe-core repository](https://github.com/dequelabs/axe-core) for more information.
+
 The complete list of rules run by axe-core can be found in [doc/rule-descriptions.md][axe-rule-descriptions].
 
 # WebDrivers

--- a/README.md
+++ b/README.md
@@ -59,12 +59,11 @@ The complete list of rules run by axe-core can be found in [doc/rule-description
 
 # WebDrivers
 
-axe-matchers supports Capybara, Selenium, and Watir webdrivers; each tested with Firefox, Chrome, Safari, and PhantomJS. Additionally, capybara-webkit and poltergeist are supported.
+axe-matchers supports Capybara, Selenium, and Watir webdrivers; each tested with Firefox, Chrome, and Safari. Additionally, selenium-chrome-headless and capybara-webkit are supported.
 
 *__Notes:__*
 
-- Auditing IFrames is not suppored in Poltergeist < 1.8.0. Upgrade to 1.8.0+ or set `skip_iframes=true` in `Axe.configure`
-- Chrome requires [ChromeDriver][chrome-driver] (tested with 2.21)
+- Chrome requires [ChromeDriver][chrome-driver] (tested with 2.35)
 - Safari requires [SafariDriver][safari-driver] (tested with 2.48)
 
 

--- a/Rakefile
+++ b/Rakefile
@@ -30,6 +30,11 @@ namespace :npm do
     sh "npm install --save axe-core@latest"
   end
 
+  desc "Upgrade axe-core dependency to latest prerelease version, overwriting package.json"
+  task :next do
+    sh "npm install --save axe-core@next"
+  end
+
   desc "Display currently-installed and latest-available versions of axe-core lib"
   task :status do
     sh "npm view axe-core version && npm list axe-core"

--- a/Rakefile
+++ b/Rakefile
@@ -67,16 +67,16 @@ namespace :cucumber do
   task :all => %w[ capybara selenium watir ]
 
   desc "Run Cucumber features with each headless browser"
-  task :headless => %w[ capybara:webkit phantomjs ]
+  task :headless => %w[ selenium:chrome:headless capybara:webkit ]
 
   desc "Run Cucumber features with Capybara driving each browser"
-  task :capybara => %w[ capybara:firefox capybara:chrome capybara:safari capybara:phantomjs capybara:poltergeist capybara:webkit ]
+  task :capybara => %w[ capybara:firefox capybara:chrome capybara:safari capybara:webkit ]
 
   desc "Run Cucumber features with Selenium driving each browser"
-  task :selenium => %w[ selenium:firefox selenium:chrome selenium:safari selenium:phantomjs ]
+  task :selenium => %w[ selenium:firefox selenium:chrome selenium:safari ]
 
   desc "Run Cucumber features with Watir driving each browser"
-  task :watir => %w[ watir:firefox watir:chrome watir:safari watir:phantomjs ]
+  task :watir => %w[ watir:firefox watir:chrome watir:safari ]
 
   desc "Run Cucumber features with Firefox under each driver"
   task :firefox => %w[ capybara:firefox selenium:firefox watir:firefox ]
@@ -87,25 +87,20 @@ namespace :cucumber do
   desc "Run Cucumber features with Safari under each driver"
   task :safari => %w[ capybara:safari selenium:safari watir:safari ]
 
-  desc "Run Cucumber features with PhantomJS under each driver"
-  task :phantomjs => %w[ capybara:poltergeist capybara:phantomjs selenium:phantomjs watir:phantomjs ]
 
   Cucumber::Rake::Task.new 'ci', 'Run Cucumber features and save results in junit xml' do |t| t.cucumber_opts = "-p capybara -p chrome --format junit --out results/cucumber/" end
 
-  Cucumber::Rake::Task.new 'capybara:webkit',       'Run Cucumber features with Capybara driving Webkit'      do |t| t.cucumber_opts = "-p capybara -p webkit" end
-  Cucumber::Rake::Task.new 'capybara:poltergeist',  'Run Cucumber features with Capybara driving Poltergeist' do |t| t.cucumber_opts = "-p capybara -p poltergeist" end
-  Cucumber::Rake::Task.new 'capybara:firefox',      'Run Cucumber features with Capybara driving Firefox'     do |t| t.cucumber_opts = "-p capybara -p firefox" end
-  Cucumber::Rake::Task.new 'capybara:chrome',       'Run Cucumber features with Capybara driving Chrome'      do |t| t.cucumber_opts = "-p capybara -p chrome" end
-  Cucumber::Rake::Task.new 'capybara:phantomjs',    'Run Cucumber features with Capybara driving PhantomJS'   do |t| t.cucumber_opts = "-p capybara -p phantomjs" end
-  Cucumber::Rake::Task.new 'capybara:safari',       'Run Cucumber features with Capybara driving Safari'      do |t| t.cucumber_opts = "-p capybara -p safari" end
+  Cucumber::Rake::Task.new 'capybara:webkit',         'Run Cucumber features with Capybara driving Webkit'            do |t| t.cucumber_opts = "-p capybara -p webkit" end
+  Cucumber::Rake::Task.new 'capybara:firefox',        'Run Cucumber features with Capybara driving Firefox'           do |t| t.cucumber_opts = "-p capybara -p firefox" end
+  Cucumber::Rake::Task.new 'capybara:chrome',         'Run Cucumber features with Capybara driving Chrome'            do |t| t.cucumber_opts = "-p capybara -p chrome" end
+  Cucumber::Rake::Task.new 'capybara:headless',       'Run Cucumber features with Capybara driving headless Chrome'   do |t| t.cucumber_opts = "-p capybara -p chrome-headless" end
+  Cucumber::Rake::Task.new 'capybara:safari',         'Run Cucumber features with Capybara driving Safari'            do |t| t.cucumber_opts = "-p capybara -p safari" end
 
   Cucumber::Rake::Task.new 'selenium:firefox',    'Run Cucumber features with Selenium driving Firefox'   do |t| t.cucumber_opts = "-p selenium -p firefox" end
   Cucumber::Rake::Task.new 'selenium:chrome',     'Run Cucumber features with Selenium driving Chrome'    do |t| t.cucumber_opts = "-p selenium -p chrome" end
-  Cucumber::Rake::Task.new 'selenium:phantomjs',  'Run Cucumber features with Selenium driving PhantomJS' do |t| t.cucumber_opts = "-p selenium -p phantomjs" end
   Cucumber::Rake::Task.new 'selenium:safari',     'Run Cucumber features with Selenium driving Safari'    do |t| t.cucumber_opts = "-p selenium -p safari" end
 
   Cucumber::Rake::Task.new 'watir:firefox',    'Run Cucumber features with Watir driving Firefox'   do |t| t.cucumber_opts = "-p watir -p firefox" end
   Cucumber::Rake::Task.new 'watir:chrome',     'Run Cucumber features with Watir driving Chrome'    do |t| t.cucumber_opts = "-p watir -p chrome" end
-  Cucumber::Rake::Task.new 'watir:phantomjs',  'Run Cucumber features with Watir driving PhantomJS' do |t| t.cucumber_opts = "-p watir -p phantomjs" end
   Cucumber::Rake::Task.new 'watir:safari',     'Run Cucumber features with Watir driving Safari'    do |t| t.cucumber_opts = "-p watir -p safari" end
 end

--- a/axe-matchers.gemspec
+++ b/axe-matchers.gemspec
@@ -42,9 +42,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec_junit_formatter', '~> 0.3'
   spec.add_development_dependency 'sinatra', '~> 2.0'
   # drivers
-  spec.add_development_dependency 'capybara', '~> 2.13'
+  spec.add_development_dependency 'capybara', '~> 2.15'
   spec.add_development_dependency 'capybara-webkit', '~> 1.14'
-  spec.add_development_dependency 'poltergeist', '~> 1.16'
   spec.add_development_dependency 'selenium-webdriver', '~> 3.5'
   spec.add_development_dependency 'watir', '~> 6.6'
+  spec.add_development_dependency 'chromedriver-helper'
 end

--- a/circle.yml
+++ b/circle.yml
@@ -4,6 +4,11 @@ machine:
   environment:
     PATH: "${HOME}/firefox:${PATH}"
 dependencies:
+  pre:
+    - curl -L -o google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+    - sudo dpkg -i google-chrome.deb
+    - sudo sed -i 's|HERE/chrome\"|HERE/chrome\" --disable-setuid-sandbox|g' /opt/google/chrome/google-chrome
+    - rm google-chrome.deb
   override:
     - bundle install
     - rake install

--- a/config/cucumber.yml
+++ b/config/cucumber.yml
@@ -1,6 +1,6 @@
 ---
 # default
-default: -p capybara -p webkit
+default: -p capybara -p chrome-headless
 
 # drivers
 capybara: -r features/support/env/capybara.rb
@@ -9,8 +9,7 @@ watir: -r features/support/env/watir.rb
 
 # browser
 webkit: BROWSER=webkit
-poltergeist: BROWSER=poltergeist
 firefox: BROWSER=firefox
 chrome: BROWSER=chrome
+chrome-headless: BROWSER=chrome:headless
 safari: BROWSER=safari
-phantomjs: BROWSER=phantomjs

--- a/examples/capybara/features/support/env.rb
+++ b/examples/capybara/features/support/env.rb
@@ -19,5 +19,4 @@ require 'axe/cucumber/step_definitions'
 #
 # axe-matchers is known to work with Capybara using the following drivers:
 # - capybara-webkit
-# - selenium (firefox, chrome, safari, ie, phantomjs)
-# - poltergeist
+# - selenium (firefox, chrome, chrome headless, safari, ie)

--- a/examples/selenium/features/support/env.rb
+++ b/examples/selenium/features/support/env.rb
@@ -29,4 +29,4 @@ end
 # https://github.com/SeleniumHQ/selenium/tree/master/rb
 #
 # axe-matchers is known to work with selenium-webdriver using:
-# chrome, firefox, internet explorer, phantomjs, safari
+# chrome, firefox, internet explorer, safari

--- a/examples/watir/features/support/env.rb
+++ b/examples/watir/features/support/env.rb
@@ -29,4 +29,4 @@ end
 # http://watirwebdriver.com/
 #
 # axe-matchers is known to work with watir-webdriver using:
-# chrome, firefox, internet explorer, phantomjs, safari
+# chrome, firefox, internet explorer, safari

--- a/features/iframes.feature
+++ b/features/iframes.feature
@@ -3,8 +3,8 @@ Feature: iframes
     Given I visit http://dylanb.github.io/uberframer.html
 
   Scenario: Audits iframes by default
-    Then there should be 3 accessibility violations
+    Then there should be 5 accessibility violations
 
   Scenario: IFrames can be skipped
     When I disable iframe auditing
-    Then the page should be accessible
+    Then the page should be accessible according to: wcag2a; skipping: region, landmark-one-main

--- a/features/support/env/capybara.rb
+++ b/features/support/env/capybara.rb
@@ -6,9 +6,6 @@ Capybara.default_driver = case $browser
                           when :webkit
                             require 'capybara-webkit'
                             :webkit
-                          when :poltergeist
-                            require 'capybara/poltergeist'
-                            :poltergeist
                           else
                             require 'selenium-webdriver'
                             Capybara.register_driver :selenium do |app|
@@ -16,6 +13,8 @@ Capybara.default_driver = case $browser
                             end
                             :selenium
                           end
+
+Capybara.default_driver = :selenium_chrome_headless
 
 Before do
   @page = Capybara.current_session

--- a/package.json
+++ b/package.json
@@ -7,6 +7,6 @@
     "url": "git+https://github.com/dequelabs/axe-matchers.git"
   },
   "dependencies": {
-    "axe-core": "^2.5.0"
+    "axe-core": "^3.0.0-beta.1"
   }
 }

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1,22 +1,16 @@
 require 'spec_helper'
 require 'capybara/rspec'
-require 'capybara-webkit'
 require 'axe/matchers'
 
 RSpec.configure do |c|
   c.include Axe::Matchers
 end
 
-Capybara.default_driver = :webkit
-
-Capybara::Webkit.configure do |config|
-  config.block_unknown_urls
-  config.allow_url("abcdcomputech.dequecloud.com")
-end
+Capybara.default_driver = :selenium_chrome_headless
 
 feature "BeAccessible", :integration, :slow do
   background do
-    visit 'http://abcdcomputech.dequecloud.com'
+    visit 'https://dequelabs.github.io/axe-fixtures/shadow-dom.html'
   end
 
   given(:subject) { page }
@@ -27,12 +21,12 @@ feature "BeAccessible", :integration, :slow do
   end
 
   scenario "check known accessible subtree" do
-    expect { expect(page).to be_accessible.within("#intro") }.to_not raise_error
-    expect { expect(page).to_not be_accessible.within("#intro") }.to raise_error(/Expected to find accessibility violations. None were detected./)
+    expect { expect(page).to be_accessible.within("#no_issues") }.to_not raise_error
+    expect { expect(page).to_not be_accessible.within("#no_issues") }.to raise_error(/Expected to find accessibility violations. None were detected./)
   end
 
   scenario "exclude known inaccessible subtree" do
-    expect { expect(page).to be_accessible.within("#topbar").excluding(".fl_left") }.to_not raise_error
-    expect { expect(page).to_not be_accessible.within("#topbar").excluding(".fl_left") }.to raise_error(/Expected to find accessibility violations. None were detected./)
+    expect { expect(page).to be_accessible.within("#list_probz").excluding("ul") }.to_not raise_error
+    expect { expect(page).to_not be_accessible.within("#list_probz").excluding("ul") }.to raise_error(/Expected to find accessibility violations. None were detected./)
   end
 end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -17,7 +17,7 @@ feature "BeAccessible", :integration, :slow do
 
   scenario "check known inaccessible page" do
     expect { expect(page).to_not be_accessible }.to_not raise_error
-    expect { expect(page).to be_accessible }.to raise_error(/Found ([4-6]) accessibility violations/)
+    expect { expect(page).to be_accessible }.to raise_error(/Found ([1-6]) accessibility violations/)
   end
 
   scenario "check known accessible subtree" do

--- a/spec/lib/axe/api/results_spec.rb
+++ b/spec/lib/axe/api/results_spec.rb
@@ -25,20 +25,30 @@ module Axe::API
               "any" => [ { "message" => "Fix from any 2" } ],
               "all" => [ { "message" => "Fix from all 2" } ]
             } ]
+          }, {
+            "help" => "V3 help",
+            "helpUrl" => "V3 url",
+            "nodes" => [ {
+              "target" => [["#target-3-1", "#target-3-2"]],
+              "html" => "V3 html",
+              "any" => [ { "message" => "Fix from any 3" } ],
+              "all" => [ { "message" => "Fix from all 3" } ]
+            } ]
           } ]
         }
 
         it "should return formatted error message" do
           subject.failure_message.tap do |message|
-            expect(message).to include("Found 2 accessibility violations")
+            
+            expect(message).to include("Found 3 accessibility violations")
 
-            expect(message).to include "V1 help", "V2 help"
-            expect(message).to include "V1 url", "V2 url"
+            expect(message).to include "V1 help", "V2 help", "V3 help"
+            expect(message).to include "V1 url", "V2 url", "V3 url"
 
-            expect(message).to include "V1 html", "V2 html"
-            expect(message).to include "#target-1-1", "#target-2-1, #target-2-2"
+            expect(message).to include "V1 html", "V2 html", "V3 html"
+            expect(message).to include "#target-1-1", "#target-2-1, #target-2-2", "#target-3-1, #target-3-2"
 
-            expect(message).to include "Fix from any 1", "Fix from all 1", "Fix from any 2", "Fix from all 2"
+            expect(message).to include "Fix from any 1", "Fix from all 1", "Fix from any 2", "Fix from all 2", "Fix from any 3", "Fix from all 3"
           end
         end
       end

--- a/spec/lib/webdriver_script_adapter/exec_eval_script_adapter_spec.rb
+++ b/spec/lib/webdriver_script_adapter/exec_eval_script_adapter_spec.rb
@@ -44,18 +44,6 @@ module WebDriverScriptAdapter
         end
       end
 
-      context "Selenium (doesn't respond to #evaluate_script)" do
-        let(:driver) { Selenium::WebDriver.for :phantomjs }
-
-        it_behaves_like "a webdriver"
-      end
-
-      context "Watir (doesn't respond to #evaluate_script)" do
-        let(:driver) { Watir::Browser.new :phantomjs }
-
-        it_behaves_like "a webdriver"
-      end
-
       context "Capybara (already responds to #evaluate_script)" do
         let(:driver) { Capybara.current_session }
 


### PR DESCRIPTION
This PR removes the deprecated PhantomJS and Poltergeist drivers and updates to Capybara's selenium_chrome_headless driver instead. It also updates to axe-core@3x, which required changing some of the fixtures tested and adding an extra test for Shadow DOM selectors. But it appears that axe-matchers was written to already handle selector arrays like the `target` returned from axe-core@3x.

From [API.md](https://github.com/dequelabs/axe-core/blob/develop/doc/API.md): 
> `target`: Array of either strings or Arrays of strings. If the item in the array is a string, then it is a CSS selector. If there are multiple items in the array each item corresponds to one level of iframe or frame. If there is one iframe or frame, there should be two entries in target. If there are three iframe levels, there should be four entries in target. If the item in the Array is an Array of strings, then it points to an element in a shadow DOM and each item (except the n-1th) in this array is a selector to a DOM element with a shadow DOM. The last element in the array points to the final shadow DOM node.

I've cc'd Jason and Sam, since they last edited the files–they could probably tell us if I botched anything. 