### PR TITLE
Deprecate a11ycheck

### DIFF
--- a/lib/axe/api/run.rb
+++ b/lib/axe/api/run.rb
@@ -12,7 +12,7 @@ require 'axe/core'
 
 module Axe
   module API
-    class A11yCheck
+    class Run
       JS_NAME = "run"
       METHOD_NAME = "#{Core::JS_NAME}.#{JS_NAME}"
 
@@ -33,10 +33,6 @@ module Axe
           Audit.new to_js, Results.new(results)
         end
       end
-
-      extend Gem::Deprecate
-      deprecate :initialize, "3.0"
-      deprecate :call, "3.0"
 
       private
 

--- a/lib/axe/matchers/be_accessible.rb
+++ b/lib/axe/matchers/be_accessible.rb
@@ -1,24 +1,24 @@
 require 'forwardable'
 require 'chain_mail/chainable'
 require 'axe/core'
-require 'axe/api/a11y_check'
+require 'axe/api/run'
 
 module Axe
   module Matchers
     class BeAccessible
       extend Forwardable
       def_delegators :@audit, :failure_message, :failure_message_when_negated
-      def_delegators :@a11y_check, :within, :excluding, :according_to, :checking, :checking_only, :skipping, :with_options
+      def_delegators :@run, :within, :excluding, :according_to, :checking, :checking_only, :skipping, :with_options
 
       extend ChainMail::Chainable
       chainable :within, :excluding, :according_to, :checking, :checking_only, :skipping, :with_options
 
       def initialize
-        @a11y_check = API::A11yCheck.new
+        @run = API::Run.new
       end
 
       def audit(page)
-        @audit ||= Core.new(page).call @a11y_check
+        @audit ||= Core.new(page).call @run
       end
 
       def matches?(page)

--- a/spec/lib/axe/api/run_spec.rb
+++ b/spec/lib/axe/api/run_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
-require 'axe/api/a11y_check'
+require 'axe/api/run'
 
 module Axe::API
-  describe A11yCheck do
+  describe Run do
 
     describe "@context" do
       let(:context) { spy('context') }

--- a/spec/lib/axe/core_spec.rb
+++ b/spec/lib/axe/core_spec.rb
@@ -23,12 +23,12 @@ module Axe
     end
 
     describe "call" do
-      let(:a11y_check) { spy('a11y_check') }
+      let(:run) { spy('run') }
 
       it "should invoke the callable in the page" do
-        core.call(a11y_check)
+        core.call(run)
 
-        expect(a11y_check).to have_received(:call).with(page)
+        expect(run).to have_received(:call).with(page)
       end
     end
   end

--- a/spec/lib/axe/matchers/be_accessible_spec.rb
+++ b/spec/lib/axe/matchers/be_accessible_spec.rb
@@ -3,21 +3,21 @@ require 'axe/matchers/be_accessible'
 
 module Axe::Matchers
   describe BeAccessible do
-    let(:a11y_check) { spy('a11y_check', call: audit) }
+    let(:run) { spy('run', call: audit) }
     let(:audit) { spy('audit') }
     let(:page) { spy('page') }
     let(:core) { spy('core') }
     before :each do
-      subject.instance_variable_set :@a11y_check, a11y_check
+      subject.instance_variable_set :@run, run
     end
 
     describe "#matches?" do
-      it "should run the a11y_check against the page" do
+      it "should run the run against the page" do
         expect(Axe::Core).to receive(:new).with(page).and_return(core)
 
         subject.matches?(page)
 
-        expect(core).to have_received(:call).with(a11y_check)
+        expect(core).to have_received(:call).with(run)
       end
 
       it "should save results" do
@@ -34,7 +34,7 @@ module Axe::Matchers
     describe "#audit" do
       it "should audit the page with an a11y check" do
         expect(Axe::Core).to receive(:new).with(page).and_return(core)
-        expect(core).to receive(:call).with(a11y_check).and_return(audit)
+        expect(core).to receive(:call).with(run).and_return(audit)
 
         expect( subject.audit(page) ).to be audit
       end
@@ -57,9 +57,9 @@ module Axe::Matchers
     end
 
     describe "#within" do
-      it "should be delegated to @a11y_check" do
+      it "should be delegated to @run" do
         subject.within(:foo, :bar)
-        expect(a11y_check).to have_received(:within).with(:foo, :bar)
+        expect(run).to have_received(:within).with(:foo, :bar)
       end
 
       it "should return self for chaining" do
@@ -68,9 +68,9 @@ module Axe::Matchers
     end
 
     describe "#excluding" do
-      it "should be delegated to @a11y_check" do
+      it "should be delegated to @run" do
         subject.excluding(:foo, :bar)
-        expect(a11y_check).to have_received(:excluding).with(:foo, :bar)
+        expect(run).to have_received(:excluding).with(:foo, :bar)
       end
 
       it "should return self for chaining" do
@@ -79,9 +79,9 @@ module Axe::Matchers
     end
 
     describe "#according_to" do
-      it "should be delegated to @a11y_check" do
+      it "should be delegated to @run" do
         subject.according_to(:foo, :bar)
-        expect(a11y_check).to have_received(:according_to).with(:foo, :bar)
+        expect(run).to have_received(:according_to).with(:foo, :bar)
       end
 
       it "should return self for chaining" do
@@ -90,9 +90,9 @@ module Axe::Matchers
     end
 
     describe "#checking" do
-      it "should be delegated to @a11y_check" do
+      it "should be delegated to @run" do
         subject.checking(:foo, :bar)
-        expect(a11y_check).to have_received(:checking).with(:foo, :bar)
+        expect(run).to have_received(:checking).with(:foo, :bar)
       end
 
       it "should return self for chaining" do
@@ -101,9 +101,9 @@ module Axe::Matchers
     end
 
     describe "#skipping" do
-      it "should be delegated to @a11y_check" do
+      it "should be delegated to @run" do
         subject.skipping(:foo, :bar)
-        expect(a11y_check).to have_received(:skipping).with(:foo, :bar)
+        expect(run).to have_received(:skipping).with(:foo, :bar)
       end
 
       it "should return self for chaining" do
@@ -112,9 +112,9 @@ module Axe::Matchers
     end
 
     describe "#checking_only" do
-      it "should be delegated to @a11y_check" do
+      it "should be delegated to @run" do
         subject.checking_only(:foo, :bar)
-        expect(a11y_check).to have_received(:checking_only).with(:foo, :bar)
+        expect(run).to have_received(:checking_only).with(:foo, :bar)
       end
 
       it "should return self for chaining" do
@@ -123,9 +123,9 @@ module Axe::Matchers
     end
 
     describe "#with_options" do
-      it "should be delegated to @a11y_check" do
+      it "should be delegated to @run" do
         subject.with_options(:foo)
-        expect(a11y_check).to have_received(:with_options).with(:foo)
+        expect(run).to have_received(:with_options).with(:foo)
       end
 
       it "should return self for chaining" do


### PR DESCRIPTION
Swapping out `a11y_check` for `run` seemed like a good thing to do ahead of a major release. The API method is used in the matchers but isn't called directly, so it seems like a low-risk change.