### PR TITLE
Include parent Node hash in CheckedNode

### DIFF
--- a/lib/axe/api/results/checked_node.rb
+++ b/lib/axe/api/results/checked_node.rb
@@ -22,12 +22,12 @@ module Axe
         end
 
         def to_h
-          {
+          super.merge({
             impact: impact,
             any: any.map(&:to_h),
             all: all.map(&:to_h),
             none: none.map(&:to_h)
-          }
+          })
         end
 
         private


### PR DESCRIPTION
I needed the `html` and `target` attributes from `CheckedNode`'s parent class `Node`.