### PR TITLE
feat: release 2.1.1

### DIFF
--- a/axe-matchers.gemspec
+++ b/axe-matchers.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name        = 'axe-matchers'
-  spec.version     = '2.1.0'
+  spec.version     = '2.1.1'
   spec.license     = 'MPL-2.0'
   spec.authors     = ['Deque Systems', 'Test Double']
   spec.email       = ['helpdesk@deque.com', 'hello@testdouble.com']

--- a/lib/axe/api/results.rb
+++ b/lib/axe/api/results.rb
@@ -6,9 +6,11 @@ module Axe
       require 'axe/api/results/rule'
 
       values do
-        attribute :url, ::String
-        attribute :timestamp
+        attribute :inapplicable, ::Array[Rule]
+        attribute :incomplete, ::Array[Rule]
         attribute :passes, ::Array[Rule]
+        attribute :timestamp
+        attribute :url, ::String
         attribute :violations, ::Array[Rule]
       end
 
@@ -23,9 +25,11 @@ module Axe
 
       def to_h
         {
-          url: url,
-          timestamp: timestamp,
+          inapplicable: inapplicable.map(&:to_h),
+          incomplete: incomplete.map(&:to_h),
           passes: passes.map(&:to_h),
+          timestamp: timestamp,
+          url: url,
           violations: violations.map(&:to_h)
         }
       end

--- a/lib/axe/api/results/check.rb
+++ b/lib/axe/api/results/check.rb
@@ -5,11 +5,12 @@ module Axe
   module API
     class Results
       class Check < ValueObject
+
         values do
+          attribute :data, ::String
           attribute :id, ::Symbol
           attribute :impact, ::Symbol
           attribute :message, ::String
-          attribute :data, ::String
           attribute :relatedNodes, ::Array[Node]
         end
 
@@ -19,13 +20,14 @@ module Axe
 
         def to_h
           {
+            data: data,
             id: id,
             impact: impact,
             message: message,
-            data: data,
             relatedNodes: relatedNodes.map(&:to_h)
           }
         end
+        
       end
     end
   end

--- a/lib/axe/api/results/checked_node.rb
+++ b/lib/axe/api/results/checked_node.rb
@@ -5,11 +5,15 @@ module Axe
   module API
     class Results
       class CheckedNode < Node
+        
         values do
           attribute :impact, ::Symbol
           attribute :any, ::Array[Check]
           attribute :all, ::Array[Check]
           attribute :none, ::Array[Check]
+          attribute :failureSummary, ::Symbol
+          attribute :html, ::String
+          attribute :target
         end
 
         def failure_messages
@@ -23,10 +27,13 @@ module Axe
 
         def to_h
           {
-            impact: impact,
-            any: any.map(&:to_h),
             all: all.map(&:to_h),
-            none: none.map(&:to_h)
+            any: any.map(&:to_h),
+            failureSummary: failureSummary,
+            html: html,
+            impact: impact,
+            none: none.map(&:to_h),
+            target: target
           }
         end
 

--- a/lib/axe/api/results/rule.rb
+++ b/lib/axe/api/results/rule.rb
@@ -30,13 +30,13 @@ module Axe
 
         def to_h
           {
-            id: id,
             description: description,
             help: help,
             helpUrl: helpUrl,
+            id: id,
             impact: impact,
+            nodes: nodes.map(&:to_h),
             tags: tags,
-            nodes: nodes.map(&:to_h)
           }
         end
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
     "type": "git",
     "url": "git+https://github.com/dequelabs/axe-matchers.git"
   },
+  "scripts": {
+    "setup": "rm -rf ./package-lock.json && npm install && rm -rf ./Gemfile.lock && bundle install",
+    "test": "rspec"
+  },
   "dependencies": {
     "axe-core": "^3.0.1"
   }


### PR DESCRIPTION
fix: extend generated results to match axe-core results  (#37)
- [x] fix: extend checked_node object with failureSummary and other attributes
- [x] fix: return results json similar to axe-core results.
- [x] fix: ci build
- [x] fix: version update - 2.1.1