### PR TITLE
ci: setup automated releases for "develop" and "master" commits

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,3 +19,9 @@ jobs:
           path: pkg
       - store_test_results:
           path: results
+      - run: 
+          name: Optionally publish
+          command: |
+            if [ "$CIRCLE_BRANCH" = "develop" ] || [ "$CIRCLE_BRANCH" = "master" ]; then 
+              .circleci/publish.sh
+            fi

--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -2,21 +2,23 @@
 
 set -e
 
-throw() { 
-  echo "$@" 1>&2
-  exit 1
-}
+# Setup `gem` credentials.
+# Based on https://medium.com/@pezholio/publishing-rubygems-using-circle-ci-2-0-1dbf06ae9942.
+mkdir ~/.gem
+echo -e "---\r\n:rubygems_api_key: Basic $RUBYGEMS_API_KEY" > ~/.gem/credentials
+chmod 0600 ~/.gem/credentials
 
 if [ "$CIRCLE_BRANCH" = "develop" ]; then
   rm -rf pkg
   # Add a ".pre.SHA" suffix to the version number.
   sed -i '' "s/spec\.version *= *\"\(.*\)\"/spec.version = \"\1.pre.$(git rev-parse --short HEAD)\"/" axe-matchers.gemspec
   rake build
-  gem push --host $(pkg/*.gem)
+  gem push $(pkg/*.gem)
 elif [ "$CIRCLE_BRANCH" = "master" ]; then
   rm -rf pkg
   rake build
-  gem push --host $(pkg/*.gem)
+  gem push $(pkg/*.gem)
 else
-  throw "Invalid branch. Refusing to publish."
+  echo "Invalid branch. Refusing to publish." 1>&2
+  exit 1
 fi

--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -e
+
+throw() { 
+  echo "$@" 1>&2
+  exit 1
+}
+
+if [ "$CIRCLE_BRANCH" = "develop" ]; then
+  rm -rf pkg
+  # Add a ".pre.SHA" suffix to the version number.
+  sed -i '' "s/spec\.version *= *\"\(.*\)\"/spec.version = \"\1.pre.$(git rev-parse --short HEAD)\"/" axe-matchers.gemspec
+  rake build
+  gem push --host $(pkg/*.gem)
+elif [ "$CIRCLE_BRANCH" = "master" ]; then
+  rm -rf pkg
+  rake build
+  gem push --host $(pkg/*.gem)
+else
+  throw "Invalid branch. Refusing to publish."
+fi

--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -5,7 +5,7 @@ set -e
 # Setup `gem` credentials.
 # Based on https://medium.com/@pezholio/publishing-rubygems-using-circle-ci-2-0-1dbf06ae9942.
 mkdir ~/.gem
-echo -e "---\r\n:rubygems_api_key: Basic $RUBYGEMS_API_KEY" > ~/.gem/credentials
+echo -e "---\r\n:rubygems_api_key: $RUBYGEMS_API_KEY" > ~/.gem/credentials
 chmod 0600 ~/.gem/credentials
 
 if [ "$CIRCLE_BRANCH" = "develop" ]; then


### PR DESCRIPTION
This patch adds CircleCI configuration for automatically publishing "pre" and "production" gems to Ruby Gems when commits land into develop and master.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Has documentation updated
- [ ] Includes new tests, or was unnecessary
- [ ] Code is reviewed for security by: << Name here >>
