### PR TITLE
build(publish.sh): fix sed command

### DIFF
--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -11,7 +11,7 @@ chmod 0600 ~/.gem/credentials
 if [ "$CIRCLE_BRANCH" = "develop" ]; then
   rm -rf pkg
   # Add a ".pre.SHA" suffix to the version number.
-  sed -i '' "s/spec\.version *= *\"\(.*\)\"/spec.version = \"\1.pre.$(git rev-parse --short HEAD)\"/" axe-matchers.gemspec
+  sed -i -e "s/spec\.version\s*=\s'\(.*\)'/spec.version='\1.pre.$(git rev-parse --short HEAD)'/" axe-matchers.gemspec 
   rake build
   gem push $(pkg/*.gem)
 elif [ "$CIRCLE_BRANCH" = "master" ]; then


### PR DESCRIPTION
It appears the `sed` on CircleCI is slightly different than what I have on OSX. This patch updates the `sed` command to work on CI.

NOTE: I have SSH'ed into CircleCI to validate this works.

Closes issue:

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: Jey
