### PR TITLE
ci: fix `gem push` command

### DIFF
--- a/.circleci/publish.sh
+++ b/.circleci/publish.sh
@@ -13,11 +13,11 @@ if [ "$CIRCLE_BRANCH" = "develop" ]; then
   # Add a ".pre.SHA" suffix to the version number.
   sed -i -e "s/spec\.version\s*=\s'\(.*\)'/spec.version='\1.pre.$(git rev-parse --short HEAD)'/" axe-matchers.gemspec 
   rake build
-  gem push $(pkg/*.gem)
+  gem push $(ls pkg/*.gem)
 elif [ "$CIRCLE_BRANCH" = "master" ]; then
   rm -rf pkg
   rake build
-  gem push $(pkg/*.gem)
+  gem push $(ls pkg/*.gem)
 else
   echo "Invalid branch. Refusing to publish." 1>&2
   exit 1


### PR DESCRIPTION
This patch adds a missing `ls` to our `.circleci/publish.sh` script. I have no idea why I removed it in #46, as nothing works without it.

`/giphy facepalm`

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Has documentation updated
- [ ] Includes new tests, or was unnecessary
- [ ] Code is reviewed for security by: << Name here >>
