### PR TITLE
ci: ensure latest npm is used

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ jobs:
           # This is essential for capybara-webkit
           name: Install System Dependencies
           command: sudo apt-get install qt5-default libqt5webkit5-dev gstreamer1.0-plugins-base gstreamer1.0-tools gstreamer1.0-x
+      - run: sudo npm install -g npm@latest
       - run: bundle install --without local
       - run: rake install
       - run: rake spec:ci


### PR DESCRIPTION
This patch ensures the latest (stable) version of `npm` is used on CI.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @wilcofiers
