### PR TITLE
ci: create GitHub release for production versions [WWD-1845]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2
 
 jobs:
-  build:
+  test:
     docker:
       - image: circleci/ruby:2.4.3-node-browsers
     steps:
@@ -20,9 +20,49 @@ jobs:
           path: pkg
       - store_test_results:
           path: results
-      - run: 
-          name: Optionally publish
+  release:
+    docker:
+      - image: circleci/ruby:2.4.3-node-browsers
+    steps:
+      - checkout
+      - run: sudo apt-get install qt5-default libqt5webkit5-dev gstreamer1.0-plugins-base gstreamer1.0-tools gstreamer1.0-x
+      - run: sudo npm install -g npm@latest
+      - run: bundle install --without local
+      - run: rake install
+      - run: .circleci/publish.sh
+  github_release:
+    docker:
+      - image: circleci/golang:1.8
+    steps:
+      - checkout
+      - run: go get gopkg.in/aktau/github-release.v0
+      - run:
+          name: Download and run GitHub release script
           command: |
-            if [ "$CIRCLE_BRANCH" = "develop" ] || [ "$CIRCLE_BRANCH" = "master" ]; then 
-              .circleci/publish.sh
-            fi
+            curl https://raw.githubusercontent.com/dequelabs/attest-release-scripts/develop/src/ruby-github-release.sh -s -o ./ruby-github-release.sh
+            chmod +x ./ruby-github-release.sh
+            ./ruby-github-release.sh
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - dependencies
+      - test:
+          requires:
+            - dependencies
+      - release:
+          requires:
+            - dependencies
+            - test
+          filters:
+            branches:
+              only:
+                - master
+                - develop
+      - github_release:
+          requires:
+            - release
+          filters:
+            branches:
+              only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,13 +47,9 @@ workflows:
   version: 2
   build:
     jobs:
-      - dependencies
       - test:
-          requires:
-            - dependencies
       - release:
           requires:
-            - dependencies
             - test
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ workflows:
   version: 2
   build:
     jobs:
-      - test:
+      - test
       - release:
           requires:
             - test


### PR DESCRIPTION
This patch refactors our CircleCI configuration significantly. Now, rather than using a single job, we run the tests and release separately. Additionally, a `github_release` job has been created which pushes a GitHub Release (tag) to GitHub after a successful production deployment.

NOTE: we're still not caching dependencies here, but this should not "slow" us down too much, since the additional time spent fetching deps will only happen during a release.

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [x] Follows the commit message policy, appropriate for next version
- [x] Has documentation updated
- [x] Includes new tests, or was unnecessary
- [x] Code is reviewed for security by: @jkodu 
