### PR TITLE
chore: update circle config to cache dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ defaults: &defaults
 restore_dependency_cache: &restore_dependency_cache
   restore_cache:
     keys:
-      - v1-gem-cache-{{ checksum "Gemfile.lock" }}
+      - v1-gem-cache-{{ checksum "Gemfile" }}
       - v1-gem-cache-
 
 jobs:
@@ -26,7 +26,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.bundle
-          key: v1-gem-cache-{{ checksum "Gemfile.lock" }}
+          key: v1-gem-cache-{{ checksum "Gemfile" }}
       - run: rake install
       - run: rake spec:ci
       - run: rake cucumber:ci
@@ -46,7 +46,7 @@ jobs:
       - save_cache:
           paths:
             - ~/.bundle
-          key: v1-gem-cache-{{ checksum "Gemfile.lock" }}
+          key: v1-gem-cache-{{ checksum "Gemfile" }}
       - run: rake install
       - run: .circleci/publish.sh
   github_release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,19 @@
 version: 2
 
+defaults: &defaults
+  docker:
+    - image: circleci/ruby:2.4.3-node-browsers
+  working_directory: ~/axe-matchers
+
+restore_dependency_cache: &restore_dependency_cache
+  restore_cache:
+    keys:
+      - v1-gem-cache-{{ checksum "Gemfile.lock" }}
+      - v1-gem-cache-
+
 jobs:
   test:
-    docker:
-      - image: circleci/ruby:2.4.3-node-browsers
+    <<: *defaults
     steps:
       - checkout
       - run:
@@ -11,7 +21,12 @@ jobs:
           name: Install System Dependencies
           command: sudo apt-get install qt5-default libqt5webkit5-dev gstreamer1.0-plugins-base gstreamer1.0-tools gstreamer1.0-x
       - run: sudo npm install -g npm@latest
-      - run: bundle install --without local
+      - <<: *restore_dependency_cache
+      - run: bundle install --without local && bundle clean
+      - save_cache:
+          paths:
+            - ~/.bundle
+          key: v1-gem-cache-{{ checksum "Gemfile.lock" }}
       - run: rake install
       - run: rake spec:ci
       - run: rake cucumber:ci
@@ -21,13 +36,17 @@ jobs:
       - store_test_results:
           path: results
   release:
-    docker:
-      - image: circleci/ruby:2.4.3-node-browsers
+    <<: *defaults
     steps:
       - checkout
       - run: sudo apt-get install qt5-default libqt5webkit5-dev gstreamer1.0-plugins-base gstreamer1.0-tools gstreamer1.0-x
       - run: sudo npm install -g npm@latest
-      - run: bundle install --without local
+      - <<: *restore_dependency_cache
+      - run: bundle install --without local && bundle clean
+      - save_cache:
+          paths:
+            - ~/.bundle
+          key: v1-gem-cache-{{ checksum "Gemfile.lock" }}
       - run: rake install
       - run: .circleci/publish.sh
   github_release:


### PR DESCRIPTION
Caching `bundler` dependencies

Reference: https://circleci.com/docs/2.0/caching/#bundler-ruby, which shows the need to run `bundle clean`.

Closes issue:
- https://github.com/dequelabs/axe-matchers/issues/47

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Has documentation updated
- [ ] Includes new tests, or was unnecessary
- [ ] Code is reviewed for security by: << Name here >>
