### PR TITLE
fix: not use named capture groups in cucumber step regex

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,7 @@ jobs:
       - run: sudo apt-get install qt5-default libqt5webkit5-dev gstreamer1.0-plugins-base gstreamer1.0-tools gstreamer1.0-x
       - run: sudo npm install -g npm@latest
       - <<: *restore_dependency_cache
+      - run: rake install
       - run: npm run test:examples
 
   release:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,11 @@ jobs:
       - run: sudo apt-get install qt5-default libqt5webkit5-dev gstreamer1.0-plugins-base gstreamer1.0-tools gstreamer1.0-x
       - run: sudo npm install -g npm@latest
       - <<: *restore_dependency_cache
+      - run: bundle install --without local && bundle clean
+      - save_cache:
+          paths:
+            - ~/.bundle
+          key: v1-gem-cache-{{ checksum "Gemfile" }}
       - run: rake install
       - run: npm run test:examples
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,6 +3,9 @@ version: 2
 defaults: &defaults
   docker:
     - image: circleci/ruby:2.4.3-node-browsers
+      environment:
+        FIREFOX_VERSION: 57.0.4
+        GECKODRIVER_VERSION: 0.19.1
   working_directory: ~/axe-matchers
 
 restore_dependency_cache: &restore_dependency_cache

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,8 @@ jobs:
     <<: *defaults
     steps:
       - checkout
-      - run:
-          # This is essential for capybara-webkit
-          name: Install System Dependencies
-          command: sudo apt-get install qt5-default libqt5webkit5-dev gstreamer1.0-plugins-base gstreamer1.0-tools gstreamer1.0-x
+      # This is essential for capybara-webkit
+      - run: sudo apt-get install qt5-default libqt5webkit5-dev gstreamer1.0-plugins-base gstreamer1.0-tools gstreamer1.0-x
       - run: sudo npm install -g npm@latest
       - <<: *restore_dependency_cache
       - run: bundle install --without local && bundle clean
@@ -35,6 +33,17 @@ jobs:
           path: pkg
       - store_test_results:
           path: results
+
+  test_examples:
+    <<: *defaults
+    steps:
+      - checkout
+      # This is essential for capybara-webkit
+      - run: sudo apt-get install qt5-default libqt5webkit5-dev gstreamer1.0-plugins-base gstreamer1.0-tools gstreamer1.0-x
+      - run: sudo npm install -g npm@latest
+      - <<: *restore_dependency_cache
+      - run: npm run test:examples
+
   release:
     <<: *defaults
     steps:
@@ -49,6 +58,8 @@ jobs:
           key: v1-gem-cache-{{ checksum "Gemfile" }}
       - run: rake install
       - run: .circleci/publish.sh
+
+  
   github_release:
     docker:
       - image: circleci/golang:1.8
@@ -67,9 +78,11 @@ workflows:
   build:
     jobs:
       - test
+      - test_examples
       - release:
           requires:
             - test
+            - test_examples
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,17 @@ jobs:
       - checkout
       # This is essential for capybara-webkit
       - run: sudo apt-get install qt5-default libqt5webkit5-dev gstreamer1.0-plugins-base gstreamer1.0-tools gstreamer1.0-x
+      - run: |
+          curl -L -o "/tmp/firefox-$FIREFOX_VERSION.tar.bz2" "https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2"
+          tar -jxf "/tmp/firefox-$FIREFOX_VERSION.tar.bz2" -C "/tmp/"
+          sudo mv "/tmp/firefox" "/opt/firefox-$FIREFOX_VERSION"
+          sudo ln -sf "/opt/firefox-$FIREFOX_VERSION/firefox" "/usr/local/bin/firefox"
+      - run: |
+          curl -L -o "/tmp/geckodriver.tar.gz" "https://github.com/mozilla/geckodriver/releases/download/v$GECKODRIVER_VERSION/geckodriver-v$GECKODRIVER_VERSION-linux64.tar.gz"
+          tar -xvzf /tmp/geckodriver.tar.gz -C /tmp/
+          sudo mv "/tmp/geckodriver" "/opt/geckodriver"
+          chmod +x /opt/geckodriver
+          sudo ln -sf "/opt/geckodriver" "/usr/local/bin/geckodriver"
       - run: sudo npm install -g npm@latest
       - <<: *restore_dependency_cache
       - run: bundle install --without local && bundle clean

--- a/examples/capybara/features/a11y.feature
+++ b/examples/capybara/features/a11y.feature
@@ -10,10 +10,10 @@ Feature: Example using default Capybara setup
   # The steps for the following scenarios are provided by the axe-matchers gem
 
   Scenario: Test whole page (known to be inaccessible, should fail)
-    Then the page should be accessible
+    Then the page should not be accessible
 
   Scenario: Test working sub-tree (should pass)
-    Then the page should be accessible within "#working"
+    Then the page should be accessible within "#intro"
 
   Scenario: Test broken sub-tree (known to be inaccessible)
-    Then the page should not be accessible within "#broken"
+    Then the page should not be accessible within "#topbar"

--- a/examples/rspec-capybara/spec/a11y_spec.rb
+++ b/examples/rspec-capybara/spec/a11y_spec.rb
@@ -11,15 +11,15 @@ describe "ABCD CompuTech (RSpec DSL)", :type => :feature, :driver => :selenium d
   end
 
   it "is known to be inaccessible, should fail" do
-    expect(page).to be_accessible
+    expect(page).not_to be_accessible
   end
 
   it "is known to have an accessible sub-tree (should pass)" do
-    expect(page).to be_accessible.within '#working'
+    expect(page).to be_accessible.within '#intro'
   end
 
   it "is known to have an inaccessible sub-tree (should fail)" do
-    expect(page).to be_accessible.within '#broken'
+    expect(page).not_to be_accessible.within '#topbar'
   end
 end
 
@@ -30,14 +30,14 @@ feature "ABCD CompuTech (Capybara DSL)", :driver => :selenium do
   end
 
   scenario "is known to be inaccessible, should fail" do
-    expect(page).to be_accessible
+    expect(page).not_to be_accessible
   end
 
   scenario "is known to have an accessible sub-tree (should pass)" do
-    expect(page).to be_accessible.within '#working'
+    expect(page).to be_accessible.within '#intro'
   end
 
   scenario "is known to have an inaccessible sub-tree (should fail)" do
-    expect(page).to be_accessible.within '#broken'
+    expect(page).not_to be_accessible.within '#topbar'
   end
 end

--- a/examples/selenium/features/a11y.feature
+++ b/examples/selenium/features/a11y.feature
@@ -7,10 +7,10 @@ Feature: Example using minimal Selenium-Webdriver setup (using firefox)
   # The steps for the following scenarios are provided by the axe-matchers gem
 
   Scenario: Test whole page (known to be inaccessible, should fail)
-    Then the page should be accessible
+    Then the page should not be accessible
 
   Scenario: Test working sub-tree (should pass)
-    Then the page should be accessible within "#working"
+    Then the page should be accessible within "#intro"
 
   Scenario: Test broken sub-tree (known to be inaccessible)
-    Then the page should not be accessible within "#broken"
+    Then the page should not be accessible within "#topbar"

--- a/examples/watir/features/a11y.feature
+++ b/examples/watir/features/a11y.feature
@@ -7,10 +7,10 @@ Feature: Example using minimal Watir-Webdriver setup (using firefox)
   # The steps for the following scenarios are provided by the axe-matchers gem
 
   Scenario: Test whole page (known to be inaccessible, should fail)
-    Then the page should be accessible
+    Then the page should not be accessible
 
   Scenario: Test working sub-tree (should pass)
-    Then the page should be accessible within "#working"
+    Then the page should be accessible within "#intro"
 
   Scenario: Test broken sub-tree (known to be inaccessible)
-    Then the page should not be accessible within "#broken"
+    Then the page should not be accessible within "#topbar"

--- a/lib/axe/cucumber/step.rb
+++ b/lib/axe/cucumber/step.rb
@@ -13,32 +13,27 @@ require 'axe/expectation'
 module Axe
   module Cucumber
     class Step
-      REGEX = /^
-
+      ###############
+      # Extracting regex into variable to allow for easier consumption elsewhere
+      ###############
       # require initial phrasing, with 'not' to negate the matcher
-      (?-x:the page should( not)? be accessible)
-
+      REGEX_CAPTURE_NEGATE = '(?-x:the page should( not)? be accessible)'
       # optionally specify which subtree to check, via CSS selector
-      (?-x:;? within "(.*?)")?
-
+      REGEX_CAPTURE_INCLUSION = '(?-x:;? within "(.*?)")?'
       # optionally specify subtrees to be excluded, via CSS selector
-      (?-x:;?(?: but)? excluding "(.*?)")?
-
+      REGEX_CAPTURE_EXCLUSION = '(?-x:;?(?: but)? excluding "(.*?)")?'
       # optionally specify ruleset via list of comma-separated tags
-      (?-x:;? according to: (.*?))?
-
+      REGEX_CAPTURE_TAGS = '(?-x:;? according to: (.*?))?'
       # optionally specify rules to check as comma-separated list of rule ids
       # in addition to default ruleset or explicit ruleset specified above via tags
       # if the 'only' keyword is supplied, then *only* the listed rules are checked, not *additionally*
-      (?-x:;?(?: and)? checking( only)?: (.*?))?
-
+      REGEX_CAPTURE_RUN_ONLY_RUN_RULES = '(?-x:;?(?: and)? checking( only)?: (.*?))?'
       # optionally specify rules to skip as comma-separated list of rule ids
-      (?-x:;?(?: but)? skipping: (.*?))?
-
+      REGEX_CAPTURE_SKIP_RULES = '(?-x:;?(?: but)? skipping: (.*?))?'
       # optionally specify custom options to pass directly to axe-core as a yaml-parsed hash or json string
-      (?-x:;? with options: (.*?))?
+      REGEX_CAPTURE_OPTIONS = '(?-x:;? with options: (.*?))?'
 
-      $/x
+      REGEX = /^#{REGEX_CAPTURE_NEGATE}#{REGEX_CAPTURE_INCLUSION}#{REGEX_CAPTURE_EXCLUSION}#{REGEX_CAPTURE_TAGS}#{REGEX_CAPTURE_RUN_ONLY_RUN_RULES}#{REGEX_CAPTURE_SKIP_RULES}#{REGEX_CAPTURE_OPTIONS}$/x
 
       def self.create_for(world)
         new(FindsPage.in(world).page)

--- a/lib/axe/cucumber/step.rb
+++ b/lib/axe/cucumber/step.rb
@@ -49,13 +49,13 @@ module Axe
       end
 
       def assert_accessibility(
-        negate = false, 
-        inclusion = "", 
-        exclusion = "", 
-        tags = "", 
-        run_only = false, 
-        run_rules = "", 
-        skip_rules = "", 
+        negate = false,
+        inclusion = "",
+        exclusion = "",
+        tags = "",
+        run_only = false,
+        run_rules = "",
+        skip_rules = "",
         options = nil
       )
 
@@ -71,7 +71,6 @@ module Axe
 
         Axe::AccessibilityExpectation.create(negate).assert @page, is_accessible
       end
-
 
       private
 

--- a/lib/axe/cucumber/step.rb
+++ b/lib/axe/cucumber/step.rb
@@ -48,17 +48,7 @@ module Axe
         @page = page
       end
 
-      def assert_accessibility(
-        negate = false,
-        inclusion = "",
-        exclusion = "",
-        tags = "",
-        run_only = false,
-        run_rules = "",
-        skip_rules = "",
-        options = nil
-      )
-
+      def assert_accessibility(negate = false, inclusion = "", exclusion = "", tags = "", run_only = false, run_rules = "", skip_rules = "", options = nil)
         is_accessible = Axe::Matchers::BeAccessible.new.tap do |a|
           a.within(*selector(inclusion))
           a.excluding(*selector(exclusion))

--- a/lib/axe/cucumber/step.rb
+++ b/lib/axe/cucumber/step.rb
@@ -16,27 +16,27 @@ module Axe
       REGEX = /^
 
       # require initial phrasing, with 'not' to negate the matcher
-      (?-x:the page should(?<negate> not)? be accessible)
+      (?-x:the page should( not)? be accessible)
 
       # optionally specify which subtree to check, via CSS selector
-      (?-x:;? within "(?<inclusion>.*?)")?
+      (?-x:;? within "(.*?)")?
 
       # optionally specify subtrees to be excluded, via CSS selector
-      (?-x:;?(?: but)? excluding "(?<exclusion>.*?)")?
+      (?-x:;?(?: but)? excluding "(.*?)")?
 
       # optionally specify ruleset via list of comma-separated tags
-      (?-x:;? according to: (?<tags>.*?))?
+      (?-x:;? according to: (.*?))?
 
       # optionally specify rules to check as comma-separated list of rule ids
       # in addition to default ruleset or explicit ruleset specified above via tags
       # if the 'only' keyword is supplied, then *only* the listed rules are checked, not *additionally*
-      (?-x:;?(?: and)? checking(?<run_only> only)?: (?<run_rules>.*?))?
+      (?-x:;?(?: and)? checking( only)?: (.*?))?
 
       # optionally specify rules to skip as comma-separated list of rule ids
-      (?-x:;?(?: but)? skipping: (?<skip_rules>.*?))?
+      (?-x:;?(?: but)? skipping: (.*?))?
 
       # optionally specify custom options to pass directly to axe-core as a yaml-parsed hash or json string
-      (?-x:;? with options: (?<options>.*?))?
+      (?-x:;? with options: (.*?))?
 
       $/x
 
@@ -48,7 +48,17 @@ module Axe
         @page = page
       end
 
-      def assert_accessibility(negate = false, inclusion = "", exclusion = "", tags = "", run_only = false, run_rules = "", skip_rules = "", options = nil)
+      def assert_accessibility(
+        negate = false, 
+        inclusion = "", 
+        exclusion = "", 
+        tags = "", 
+        run_only = false, 
+        run_rules = "", 
+        skip_rules = "", 
+        options = nil
+      )
+
         is_accessible = Axe::Matchers::BeAccessible.new.tap do |a|
           a.within(*selector(inclusion))
           a.excluding(*selector(exclusion))
@@ -61,6 +71,7 @@ module Axe
 
         Axe::AccessibilityExpectation.create(negate).assert @page, is_accessible
       end
+
 
       private
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,11 @@
   },
   "scripts": {
     "setup": "rm -rf ./package-lock.json && npm install && rm -rf ./Gemfile.lock && bundle install",
+    "test:examples:cucumber-watir": "cd examples/watir && rm -rf ./Gemfile.lock && bundle install && bundle exec cucumber",
+    "test:examples:cucumber-selenium": "cd examples/selenium && rm -rf ./Gemfile.lock && bundle install && bundle exec cucumber",
+    "test:examples:cucumber-capybara": "cd examples/capybara && rm -rf ./Gemfile.lock && bundle install && bundle exec cucumber",
+    "test:examples:rspec-capybara": "cd examples/rspec-capybara && rm -rf ./Gemfile.lock && bundle install && bundle exec rspec",
+    "test:examples": "npm run test:examples:cucumber-watir && npm run test:examples:cucumber-selenium && npm run test:examples:cucumber-capybara && npm run test:examples:rspec-capybara",
     "test": "rspec",
     "changelog": "standard-version -a --skip.tag=true --skip.commit=true --skip.bump=true",
     "format": "bundle exec rubocop --config rubocop.yml --auto-correct --fix-layout"

--- a/spec/lib/axe/cucumber/step_regex_spec.rb
+++ b/spec/lib/axe/cucumber/step_regex_spec.rb
@@ -30,7 +30,10 @@ module CustomMatchers
     private
 
     def to_hash(matchdata)
-      Hash[matchdata.names.map(&:to_sym).zip matchdata.captures]
+      # Note: since not using named captures, have to use index look-up for converting matches to hash
+      # Doc: https://ruby-doc.org/core-2.4.0/MatchData.html
+      # Hash[matchdata.names.map(&:to_sym).zip matchdata.captures]
+      { :negate => matchdata[1], :inclusion => matchdata[2], :exclusion => matchdata[3], :tags => matchdata[4], :run_only => matchdata[5], :run_rules => matchdata[6], :skip_rules => matchdata[7], :options => matchdata[8] }
     end
   end
 


### PR DESCRIPTION
As of `> cucumber 2.2` named capture groups in regular expressions has been deprecated, which lead to an error like below, when using `axe-matchers` with latest version of cucumber.

![image](https://user-images.githubusercontent.com/20978252/60964473-4d65dd80-a30b-11e9-9a9e-63966236587c.png)


See also, [this thread](https://github.com/cucumber/cucumber/issues/329#issuecomment-361783591) which highlights why named capture groups were disallowed in cucumber, for further context.

**This PR does the below:**
- updates the regex to not use named capture groups but still have the benefit of capture groups, thus allowing for axe matchers to play well with latest version of cucumber.
- update specs to adapt to capture groups over named capture groups
- updates the example test cases to actually test against nodes in the provided url.
- runs examples tests in CI (closed separate PR https://github.com/dequelabs/axe-matchers/pull/63, which was aiming to tackle just this). Running examples in CI failed, as `geckodriver` was missing thus had to change circle to install required modules.

Closes issue:
- https://github.com/dequelabs/axe-matchers/issues/58
- https://github.com/dequelabs/axe-matchers/issues/31

## Reviewer checks

**Required fields, to be filled out by PR reviewer(s)**
- [ ] Follows the commit message policy, appropriate for next version
- [ ] Has documentation updated
- [ ] Includes new tests, or was unnecessary
- [ ] Code is reviewed for security by: << Name here >>
